### PR TITLE
Define default subtask selection on App/Task entry

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -35,8 +35,15 @@ impl App<'_> {
         }
     }
 
-    pub fn get_selected_position(&self) -> Option<usize> {
-        self.storage.get_selected_position()
+    pub fn get_or_init_selected_position(&mut self) -> usize {
+        match self.storage.get_selected_position() {
+            Some(position) => position,
+            None => {
+                self.storage.set_selected_position(0);
+                0
+            },
+        }
+
     }
 
     pub fn get_selected_task(&self) -> Option<&Task> {

--- a/src/render.rs
+++ b/src/render.rs
@@ -59,7 +59,7 @@ pub fn render_app(frame: &mut Frame, app: &mut App) {
 
     let elements_view_constraint = Constraint::Min(elements_list.len() as u16);
 
-    let mut selected_task_state = ListState::default().with_selected(app.get_selected_position());
+    let mut selected_task_state = ListState::default().with_selected(app.get_or_init_selected_position().into());
 
     if !app.find_parents_titles().is_empty() {
         let stack_view_constraint = Constraint::Length(2 + app.find_parents_titles().len() as u16);


### PR DESCRIPTION
It ensures that when entering app or task without any previously selected tasks, the first subtask is selected by default