### PR TITLE
Fix unexpected subtask selection behavior during task insertion

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -40,14 +40,8 @@ impl App<'_> {
         }
     }
 
-    pub fn get_or_init_selected_position(&mut self) -> usize {
-        match self.storage.get_selected_position() {
-            Some(position) => position,
-            None => {
-                self.storage.set_selected_position(0);
-                0
-            }
-        }
+    pub fn get_selected_position(&mut self) -> Option<usize> {
+        self.storage.get_selected_position()
     }
 
     pub fn get_selected_task(&self) -> Option<&Task> {
@@ -246,7 +240,7 @@ impl App<'_> {
                 Some(position) => {
                     self.storage
                         .insert_task_at(parent, task_data, position)
-                        .expect("Position out of bounds");
+                        .expect(&format!("Position {:?} out of bounds", position));
                     self.move_selection_to(position.into());
                 }
                 None => {

--- a/src/render.rs
+++ b/src/render.rs
@@ -65,7 +65,7 @@ pub fn render_app(frame: &mut Frame, app: &mut App) {
 
     let elements_view_constraint = Constraint::Min(elements_list.len() as u16);
 
-    let mut selected_task_state = ListState::default().with_selected(app.get_or_init_selected_position().into());
+    let mut selected_task_state = ListState::default().with_selected(app.get_selected_position());
 
     if !app.find_parents_titles().is_empty() {
         let stack_view_constraint = Constraint::Length(2 + app.find_parents_titles().len() as u16);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -47,16 +47,26 @@ impl AppStorage {
                 self.tasks.entry(parent_id).or_default().children.insert(index, task.id);
 
                 self.tasks.insert(task.id, task);
-            }
+            },
             ParentTask::Root => {
-                let target_index_map_entry = self
+                let root_tasks_ids = self
                     .tasks
                     .iter()
                     .filter(|(_, task)| task.parent == ParentTask::Root)
-                    .nth(index)
-                    .and_then(|(id, _)| self.tasks.get_index_of(id))?;
+                    .map(|(id, _)| id)
+                    .collect::<Vec<_>>();
 
-                self.tasks.shift_insert(target_index_map_entry, task.id, task);
+                if index == root_tasks_ids.len() {
+                    self.insert_task(parent, task.into());
+                    return Some(());
+                }
+                
+                let target_index_map_index = root_tasks_ids
+                    .iter()
+                    .nth(index)
+                    .and_then(|id| self.tasks.get_index_of(*id))?;
+
+                self.tasks.shift_insert(target_index_map_index, task.id, task);
             }
         }
 


### PR DESCRIPTION
Now, subtasks are only selected during task creation and not auto-selected in render.rs when empty.